### PR TITLE
changes to data model to facilitate API construction.

### DIFF
--- a/dnd.json
+++ b/dnd.json
@@ -1,246 +1,411 @@
 {
-	"Dungeons": {
-		"Castles": {
-			"questions": [
-				 {
-				 	"id": 1,
-				 	"subject": "The castle sits...",
-					"predicate":["Atop a mountain.",
-					"On a hill overlooking a wide plain.",
-					"At the fork of a river.",
-					"On a narrow, rocky peninsula.",
-					"Above a seaside cliff.",
-					"On a hill overlooking a river valley.",
-					"On a hill rising out of a swamp.",
-					"On a hill overlooking a forest.",
-					"Astride a desert oasis or natural spring.",
-					 "On a ridge overlooking a frozen plain."]
-				},
-				{
+	"Category": [{
+		"Dungeons": [{
+			"type": "Castle",
+			"id": 9999,
+			"details": {
+				"description": [{
+					"id": 1,
+					"dieToRoll": 10,
+					"subject": "The castle sits ",
+					"predicate": ["Atop a mountain.",
+						"On a hill overlooking a wide plain.",
+						"At the fork of a river.",
+						"On a narrow, rocky peninsula.",
+						"Above a seaside cliff.",
+						"On a hill overlooking a river valley.",
+						"On a hill rising out of a swamp.",
+						"On a hill overlooking a forest.",
+						"Astride a desert oasis or natural spring.",
+						"On a ridge overlooking a frozen plain."
+					]
+				}, {
 					"id": 2,
+					"dieToRoll": 12,
 					"subject": "The castle was built by ",
 					"predicate": [
-					"A wise king or queen.",
-					"An ambitious lord or lady.",
-					"An evil tyrant.",
-					"A mighty warrior or warlord.",
-					"A retired adventurer.",
-					"A celebrated war hero.",
-					"An unscrupulous king or queen.",
-					"A vain lord or lady.",
-					"A powerful witch or wizard.",
-					"A beloved sovereign.",
-					"A prosperous merchant.",
-					"A member of an ancient noble house."
+						"A wise king or queen.",
+						"An ambitious lord or lady.",
+						"An evil tyrant.",
+						"A mighty warrior or warlord.",
+						"A retired adventurer.",
+						"A celebrated war hero.",
+						"An unscrupulous king or queen.",
+						"A vain lord or lady.",
+						"A powerful witch or wizard.",
+						"A beloved sovereign.",
+						"A prosperous merchant.",
+						"A member of an ancient noble house."
 					]
-				},
-				{
+				}, {
 					"id": 3,
-					"subject": "The castle was built...",
-					"predicate": [ 
-					"In a past age.",
-					"Hundreds of years ago.",
-					"A few decades ago.",
-					"Within the past decade."]
-				},
-				{
+					"dieToRoll": 4,
+					"subject": "The castle was built ",
+					"predicate": [
+						"In a past age.",
+						"Hundreds of years ago.",
+						"A few decades ago.",
+						"Within the past decade."
+					]
+				}, {
 					"id": 4,
-					"subject": "Currently, the castle's condition is...",
+					"dieToRoll": 6,
+					"subject": "Currently, the castle's condition is ",
 					"predicate": [
-					"Perfect; upkeep has been fastidious.",
-					"Good; it been well-maintained.",
-					"Decent; there are only a few cracks in the walls, but the place can withstand a siege.",
-					"Fair; the castle has seen better days.",
-					"Poor; the walls and towers are in dire need of repairs.",
-					"Decrepit; the place is practically a ruin."]
-				},
-				{
+						"Perfect; upkeep has been fastidious.",
+						"Good; it been well-maintained.",
+						"Decent; there are only a few cracks in the walls, but the place can withstand a siege.",
+						"Fair; the castle has seen better days.",
+						"Poor; the walls and towers are in dire need of repairs.",
+						"Decrepit; the place is practically a ruin."
+					]
+				}, {
 					"id": 5,
-					"subject": "Presently, the castle is occupied by...",
+					"dieToRoll": 12,
+					"subject": "Presently, the castle is occupied by ",
 					"predicate": [
-					"A member of the royal family.",
-					"An ambitious lord or lady.",
-					"An evil tyrant.",
-					"An elderly lord or lady.",
-					"A brash, young lord or lady.",
-					"A mercenary company.",
-					"A fearsome warlord or retired sellsword.",
-					"A wealthy merchant.",
-					"A retired pirate or thief.",
-					"A former adventurer.",
-					"An absentee noble lord.",
-					"The crown, but the king or queen rarely stays here."]
-				},
-				{
+						"A member of the royal family.",
+						"An ambitious lord or lady.",
+						"An evil tyrant.",
+						"An elderly lord or lady.",
+						"A brash, young lord or lady.",
+						"A mercenary company.",
+						"A fearsome warlord or retired sellsword.",
+						"A wealthy merchant.",
+						"A retired pirate or thief.",
+						"A former adventurer.",
+						"An absentee noble lord.",
+						"The crown, but the king or queen rarely stays here."
+					]
+				}, {
 					"id": 6,
-					"subject": "The position or territory is worth defending because...",
+					"dieToRoll": 12,
+					"subject": "The position or territory is worth defending because ",
 					"predicate": [
-					 "The surrounding land is excellent for growing crops.",
-					 "The nearby mines are rich in ores or gems.",
-					 "The surrounding land is excellent for grazing livestock.",
-					"The nearby pass is the easiest way to cross the tains.",
-					 "The nearby harbor is important for trade.",
-					 "The nearby river is important for trade.",
-					"The nearby source of freshwater is precious is in this on.",
-					 "The wild lands beyond are full of threats.",
-					"The surrounding lands are part of a long-standing itorial dispute.",
-					 "The surrounding land is held sacred.",
-					 "The nearby lands are home to a rare herb, tree, or creature that has magical uses."]
-				},
-				{
+						"The surrounding land is excellent for growing crops.",
+						"The nearby mines are rich in ores or gems.",
+						"The surrounding land is excellent for grazing livestock.",
+						"The nearby pass is the easiest way to cross the tains.",
+						"The nearby harbor is important for trade.",
+						"The nearby river is important for trade.",
+						"The nearby source of freshwater is precious is in this on.",
+						"The wild lands beyond are full of threats.",
+						"The surrounding lands are part of a long-standing itorial dispute.",
+						"The surrounding land is held sacred.",
+						"The nearby lands are home to a rare herb, tree, or creature that has magical uses."
+					]
+				}, {
 					"id": 7,
-					"subject": "The castle’s outer defenses include...",
+					"dieToRoll": 10,
+					"subject": "The castle’s outer defenses include ",
 					"predicate": [
-					 "Very high stone walls.",
-					 "Incredibly thick stone walls.",
-					 "A series of curtain walls and gatehouses.",
-					 "A treacherous climb to reach the castle walls.",
-					 "A moat filled with putrescent water.",
-					 "A moat filled with thick, boot-sucking mud.",
-					 "A moat filled with sharp spikes.",
-					 "A moat that is home to one or more dangerous aquatic beasts.",
-					 "An immense barbican.",
-					 "A narrow footbridge to reach the postern."]
-				},
-				{
+						"Very high stone walls.",
+						"Incredibly thick stone walls.",
+						"A series of curtain walls and gatehouses.",
+						"A treacherous climb to reach the castle walls.",
+						"A moat filled with putrescent water.",
+						"A moat filled with thick, boot-sucking mud.",
+						"A moat filled with sharp spikes.",
+						"A moat that is home to one or more dangerous aquatic beasts.",
+						"An immense barbican.",
+						"A narrow footbridge to reach the postern."
+					]
+				}, {
 					"id": 8,
-					"subject": "The castle can be held effectively by as few as...",
+					"dieToRoll": 6,
+					"subject": "The inner keep's defenses include ",
 					"predicate": [
-					"5 soldiers and 20 archers.",
-					"20 soldiers, 5 knights, and 20 archers.",
-					"50 soldiers, 10 knights, and 40 archers.",
-					"20 knights, 20 archers, and 5 warmages.",
-					"100 soldiers, 50 archers, and 5 warmages.",
-					"100 soldiers, 20 knights, and 50 archers.",
-					"200 soldiers, 50 knights, and 100 archers.",
-					"200 soldiers, 100 knights, and 200 archers."]
-				},
-				{
+						"hundreds of arrow slits.",
+						"one of the world's largest dual-porticullis gates.",
+						"a winding climb to reaqch the entrance.",
+						"several covered parapets with murder holes under which intruders must pass.",
+						"a wide courtyard surrounded by flanking towers in the curtain wall."
+					]
+				}, {
 					"id": 9,
-					"subject": "In addition to its garrison, the castle can hold foodstores to withstand a three-month siege for up to...",
+					"dieToRoll": 8,
+					"subject": "The castle can be held effectively by as few as ",
+					"predicate": [{
+						"soldiers": 5,
+						"archers": 20
+					}, {
+						"soldiers": 20,
+						"knights": 5,
+						"archers": 20
+					}, {
+						"soldiers": 10,
+						"knights": 10,
+						"archers": 40
+					}, {
+						"knights": 20,
+						"warmages": 5,
+						"archers": 20
+					}, {
+						"soldiers": 100,
+						"warmages": 5,
+						"archers": 50
+					}, {
+						"soldiers": 100,
+						"knights": 20,
+						"archers": 50
+					}, {
+						"soldiers": 200,
+						"knights": 50,
+						"archers": 100
+					}, {
+						"soldiers": 200,
+						"knights": 100,
+						"archers": 200
+					}]
+				}, {
+					"id": 6,
+					"dieToRoll": 10,
+					"subject": "In addition to its garrison, the castle can hold foodstores to withstand a three-month siege for up to ",
+					"predicate": [{
+						"quantity": [50, 100, 200, 500, 1000, 2000],
+						"type": "people"
+					}]
+
+				}, {
+					"id": 12,
+					"dieToRoll": 10,
+					"subject": "The castle is known for ",
 					"predicate": [
-					"50 people.",
-					"100 people.",
-					"200 people.",
-					"500 people.",
-					"1,000 people.",
-					"2,000 people."]
-				},
-				{
-					"id": 10,
-					"subject": "The castle is known for...",
-					"predicate": [
-					"Withstanding a grueling, lengthy siege.",
-					"Suffering an immense conflagration.",
-					"Changing hands several times over the course of the same war." ,
-					"Bringing ill-fortune to those who hold it.",
-					"Being haunted by a former occupant.",
-					"Never falling in a siege.",
-					"Welcoming travelers seeking refuge.",
-					"Turning away travelers seeking refuge.",
-					"Its unusual architectural style.",
-					 "Its beautiful, historic tapestries.",
-					 "Its breathtakingly beautiful chapel.",
-					 "The quality of its meals."]
-				},
-				{
-					"id": 11,
+						"Withstanding a grueling, lengthy siege.",
+						"Suffering an immense conflagration.",
+						"Changing hands several times over the course of the same war.",
+						"Bringing ill-fortune to those who hold it.",
+						"Being haunted by a former occupant.",
+						"Never falling in a siege.",
+						"Welcoming travelers seeking refuge.",
+						"Turning away travelers seeking refuge.",
+						"Its unusual architectural style.",
+						"Its beautiful, historic tapestries.",
+						"Its breathtakingly beautiful chapel.",
+						"The quality of its meals."
+					]
+				}, {
+					"id": 12,
+					"dieToRoll": 10,
 					"subject": "What is rumored to be hidden in the castle?",
 					"predicate": [
-					"An underground tunnel that can serve as a last-gasp escape route.",
-					"The weapon of a long-dead hero.",
-					"The preserved head of an ancient villain.",
-					"A long-lost religious artifact.",
-					"A missing lord or lady.",
-					"A book of vile curses.",
-					"A book of dark and ancient secrets.",
-					"A cursed treasure hoard.",
-					"The last bottle of famous vintage of wine.",
-					 "A lost work of a celebrated artist.",
-					 "The crypt of an ancient sovereign.",
-					 "An unhatched dragon egg."]
-				},
-				{
-					"id": 12,
-					"subject": "Rooms: This chamber is...",
-					"predicate": [ "An antechamber or waiting room.",
-					"An armory.",
-					"An aviary, dovecote, owlery, or rookery.",
-					"A banquet hall.",
-					"The barracks.",
-					"A bath or privy.",
-					"A bedroom (d3): 1. simple; 2. comfortable; 3. luxurious.",
-					"A chapel or shrine.",
-					"A crypt.",
-					 "An intimate or informal dining room.",
-					 "A dressing room.",
-					 "A gallery (d6): 1. armor and weaponry; 2. paintings; 3. sculptures; 4.tapestries; 5. hunting trophies; 6. trophies of war.",
-					 "A guardroom.",
-					 "A kennel, menagerie, or stable.",
-					 "The kitchen.",
-					 "A library or study.",
-					 "A pantry.",
-					 "Store room for mundane supplies or a cistern for drinking water.",
-					 "The throne room.",
-					 "A treasure vault (likely hidden and/or protected by traps)."]
-				
-				},
-				{
-					"id": 13,
-					"subject": "Features: You notice...",
+						"An underground tunnel that can serve as a last-gasp escape route.",
+						"The weapon of a long-dead hero.",
+						"The preserved head of an ancient villain.",
+						"A long-lost religious artifact.",
+						"A missing lord or lady.",
+						"A book of vile curses.",
+						"A book of dark and ancient secrets.",
+						"A cursed treasure hoard.",
+						"The last bottle of famous vintage of wine.",
+						"A lost work of a celebrated artist.",
+						"The crypt of an ancient sovereign.",
+						"An unhatched dragon egg."
+					]
+				}, {
+					"id": 20,
+					"dieToRoll": 10,
+					"subject": "Rooms: This chamber is ",
 					"predicate": [
-					"An armchair flanked by two sconces.",
-					"A large armoire or buffet cabinet.",
-					"A bench with a cusion.",
-					"A brazier.",
-					"A candelabrum on a large table.",
-					"A plain chair beside a window.",
-					"A heavy wooden chest.",
-					"A chest of drawers with a blanket on top.",
-					"A desk with some quills and parchment.",
-					 "A fireplace with a mantle.",
-					 "A fireplace with a small pile of wood.",
-					 "A fresco with a padded chair beneath it.",
-					 "Portrait of a noble.",
-					 "A painting of a landscape or seascape.",
-					 "A bust on a pedestal.",
-					 "A shelf containing books or knick knacks.",
-					 "A low table in front of a small sofa.",
-					 "A large table beneath a chandelier.",
-					 "An ornate tapestry.",
-					 "A small wall basin and font."]
-				},
-				{
+						"An antechamber or waiting room.",
+						"An armory.",
+						"An aviary, dovecote, owlery, or rookery.",
+						"A banquet hall.",
+						"The barracks.",
+						"A bath or privy.", {
+							"modifiedBedroom": {
+								"prefix": "a ",
+								"suffix": " bedroom.",
+								"dieToRoll": 3,
+								"adjective": [
+									"simple", "comfortable", "luxurious"
+								]
+							}
+						},
+						"A chapel or shrine.",
+						"A crypt.",
+						"An intimate or informal dining room.",
+						"A dressing room.", {
+							"modifiedGallery": {
+								"prefix": "a ",
+								"preposition": "gallery of ",
+								"dieToRoll": 6,
+								"nouns": [
+									"armor and weaponry.",
+									"paintings.",
+									"sculptures.",
+									"tapestries.",
+									"hunting trophies.",
+									"trophies of war."
+								]
+							}
+						},
+						"A guardroom.",
+						"A kennel, menagerie, or stable.",
+						"The kitchen.",
+						"A library or study.",
+						"A pantry.",
+						"Store room for mundane supplies or a cistern for drinking water.",
+						"The throne room.",
+						"A treasure vault (likely hidden and/or protected by traps)."
+					]
+
+				}, {
 					"id": 14,
-					"subject": "Under siege: You come upon...",
-					"predicate": [ 
-					"A squad of archers hustling up a stair.",
-					"A patrol of guards brandishing weapons.",
-					"A guard shouting instructions.",
-					"A knight hurrying to the stables.",
-					"A servant cowering in a hiding place.",
-					"A curious child peaking out a window.",
-					"A servant kneeling in prayer.",
-					"A noble hastily penning a letter.",
-					"A squire aiding a knight with his armor.",
-					 "A healer checking over his potions."]
-				},
-				{
-					"id": 15,
-					"subject": "In peace: You come upon...",
+					"dieToRoll": 20,
+					"subject": "Features: You notice ",
 					"predicate": [
-					"The huntsman cleaning a recent kill.",
-					"The kennelmaster leading a leashed dog.",
-					"The horsemaster instructing a young rider.",
-					"The armorer scolding an apprentice.",
-					"A maid fussing over her lady’s dress.",
-					"The tutor or sage lost in a book.",
-					"The chaplain whispering with a maid.",
-					"A maid polishing an ornamental shield.",
-					"A servant carrying a tray of food.",
-					 "Several archers practicing in the yard."]
+						"An armchair flanked by two sconces.",
+						"A large armoire or buffet cabinet.",
+						"A bench with a cusion.",
+						"A brazier.",
+						"A candelabrum on a large table.",
+						"A plain chair beside a window.",
+						"A heavy wooden chest.",
+						"A chest of drawers with a blanket on top.",
+						"A desk with some quills and parchment.",
+						"A fireplace with a mantle.",
+						"A fireplace with a small pile of wood.",
+						"A fresco with a padded chair beneath it.",
+						"Portrait of a noble.",
+						"A painting of a landscape or seascape.",
+						"A bust on a pedestal.",
+						"A shelf containing books or knick knacks.",
+						"A low table in front of a small sofa.",
+						"A large table beneath a chandelier.",
+						"An ornate tapestry.",
+						"A small wall basin and font."
+					]
+				}, {
+					"id": 15,
+					"dieToRoll": 10,
+					"subject": "Under siege: You come upon ",
+					"predicate": [
+						"A squad of archers hustling up a stair.",
+						"A patrol of guards brandishing weapons.",
+						"A guard shouting instructions.",
+						"A knight hurrying to the stables.",
+						"A servant cowering in a hiding place.",
+						"A curious child peaking out a window.",
+						"A servant kneeling in prayer.",
+						"A noble hastily penning a letter.",
+						"A squire aiding a knight with his armor.",
+						"A healer checking over his potions."
+					]
+				}, {
+					"id": 16,
+					"dieToRoll": 10,
+					"subject": "In peace: You come upon ",
+					"predicate": [
+						"The huntsman cleaning a recent kill.",
+						"The kennelmaster leading a leashed dog.",
+						"The horsemaster instructing a young rider.",
+						"The armorer scolding an apprentice.",
+						"A maid fussing over her lady’s dress.",
+						"The tutor or sage lost in a book.",
+						"The chaplain whispering with a maid.",
+						"A maid polishing an ornamental shield.",
+						"A servant carrying a tray of food.",
+						"Several archers practicing in the yard."
+					]
+				}],
+				"usedWith": [{
+					"name": "castle dungeons",
+					"id": 9999
+				}, {
+					"name": "castle inhabitants",
+					"id": 9999
+				}, {
+					"name": "noble houses",
+					"id": 9999
+				}, {
+					"name": "allies",
+					"titles": [{
+						"name": "nobles",
+						"id": 9999
+					}, {
+						"name": "knights",
+						"id": 9999
+					}]
+				}],
+				"keyWords": [
+					"castle", "lord", "lady",
+					"king", "queen", "prince",
+					"princess", "knight",
+					"stronghold", "defense", "siege",
+					"battlement", "rampart", "merlin"
+				],
+				"relatedTables": [{
+					"name": "prisons",
+					"id": 9999
+				}]
+			},
+
+		}, {
+			"type": "Caverns",
+			"id": 9999,
+			"details": {
+				"description": [{
+
+				}],
+			}
+		}, {
+			"type": "Castle Dungeons",
+			"id": 9999,
+			"details": {
+				"description": [{
+
+				}],
+			}
+		}, {
+			"type": "Mine",
+			"id": 9999,
+			"details": {
+				"description": [{
+
+				}],
+			}
+		}, {
+			"type": "Monastery",
+			"id": 9999,
+			"details": {
+				"description": [{
+
+				}],
+			}
+		}, {
+			"type": "Prison",
+			"id": 9999,
+			"details": {
+				"description": [{
+
+				}],
+			}
+		}, {
+			"type": "Temple",
+			"id": 9999,
+			"details": {
+				"description": {
+
 				}
-			]
-		}
-	}
+			}
+		}, {
+			"type": "Tomb",
+			"id": 9999,
+			"details": {
+				"description": {
+
+				}
+			}
+		}],
+		"Factions": [{
+			"type": "Assassin's guilds",
+			"id": 9999,
+			"details": {
+				"description": [{
+
+				}]
+			}
+		}]
+	}],
 }


### PR DESCRIPTION
"id":9999 is intended to be a placeholder until a decision is made on how to create unique IDs that can be used for cross-referencing tables.  I haven't tested this with JS generating random outputs from document properties, so feel free to leave it pending until I can.
